### PR TITLE
Update service_controller.py

### DIFF
--- a/server/openapi_server/controllers/service_controller.py
+++ b/server/openapi_server/controllers/service_controller.py
@@ -14,7 +14,7 @@ def service():  # noqa: E501
     service = Service(
         name="date-annotator-example",
         version="0.2.1",
-        license="Apache-2.0",
+        license="apache-2.0",
         repository="github:nlpsandbox/date-annotator-example",
         description="An example implementation of the NLP Sandbox Date " +
                     "Annotator",


### PR DESCRIPTION
Since we are conforming to the list of github license keywords, we should either adhere to that or add other case possibilities to the enum list in the Service schema.

Fixes #54 