### PR TITLE
Add reverse proxy to isolate annotator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,6 @@ services:
       context: server
       dockerfile: Dockerfile
     container_name: date-annotator
-    healthcheck:
-      test: curl --fail http://localhost:8080/api/v1/healthCheck
-      interval: 10s
-      timeout: 5s
-      retries: 5
     networks:
       - nlp-sandbox-internal
 
@@ -20,8 +15,8 @@ services:
     container_name: nginx
     restart: always
     environment:
-      - SERVER_HOST=date-annotator
-      - SERVER_PORT=8080
+      - TOOL_HOST=date-annotator
+      - TOOL_PORT=8080
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/templates:/etc/nginx/templates:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,28 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - nlp-sandbox-internal
+
+  nginx:
+    image: nginx:1.19.6-alpine
+    container_name: nginx
+    restart: always
+    environment:
+      - SERVER_HOST=date-annotator
+      - SERVER_PORT=8080
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/templates:/etc/nginx/templates:ro
+    networks:
+      - nlp-sandbox
+      - nlp-sandbox-internal
     ports:
-      - "8080:8080"
+      - "80:80"
+    depends_on:
+      - date-annotator
+
+networks:
+  nlp-sandbox:
+  nlp-sandbox-internal:
+    internal: true

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,8 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+include conf.d/events.conf;
+include conf.d/http.conf;

--- a/nginx/templates/events.conf.template
+++ b/nginx/templates/events.conf.template
@@ -1,0 +1,3 @@
+events {
+    worker_connections 1024;
+}

--- a/nginx/templates/http.conf.template
+++ b/nginx/templates/http.conf.template
@@ -1,0 +1,29 @@
+http {
+    upstream date-annotator {
+        server ${SERVER_HOST}:${SERVER_PORT};
+        keepalive 15;
+    }
+
+    server {
+        listen 80;
+        server_name date-annotator;
+
+        error_log   /var/log/nginx/date-annotator.error.log;
+        access_log  /var/log/nginx/date-annotator.access.log;
+
+        location / {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header Host $http_host;
+
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+
+            proxy_set_header Connection "Keep-Alive";
+            proxy_set_header Proxy-Connection "Keep-Alive";
+
+            proxy_pass http://date-annotator;
+        }
+    }
+}

--- a/nginx/templates/http.conf.template
+++ b/nginx/templates/http.conf.template
@@ -1,15 +1,15 @@
 http {
-    upstream date-annotator {
-        server ${SERVER_HOST}:${SERVER_PORT};
+    upstream tool {
+        server ${TOOL_HOST}:${TOOL_PORT};
         keepalive 15;
     }
 
     server {
         listen 80;
-        server_name date-annotator;
+        server_name tool;
 
-        error_log   /var/log/nginx/date-annotator.error.log;
-        access_log  /var/log/nginx/date-annotator.access.log;
+        error_log   /var/log/nginx/tool.error.log;
+        access_log  /var/log/nginx/tool.access.log;
 
         location / {
             proxy_set_header X-Real-IP $remote_addr;
@@ -23,7 +23,7 @@ http {
             proxy_set_header Connection "Keep-Alive";
             proxy_set_header Proxy-Connection "Keep-Alive";
 
-            proxy_pass http://date-annotator;
+            proxy_pass http://tool;
         }
     }
 }

--- a/server/openapi_server/__main__.py
+++ b/server/openapi_server/__main__.py
@@ -9,7 +9,7 @@ app = connexion.App(__name__, specification_dir='./openapi/')
 app.app.json_encoder = encoder.JSONEncoder
 app.add_api('openapi.yaml', pythonic_params=True)
 
-# Configuring / to return the service information (required by NLP Sandbox)
+# Set / to show the tool information
 app.add_url_rule('/', 'root', lambda: flask.redirect('/api/v1/tool'))
 
 


### PR DESCRIPTION
I propose to add nginx as a reverse proxy in docker-compose.yml to prevent the annotator from establishing remote connections that the users may not be aware of.

The user can use the same docker-compose.yml to test any date annotators submitted to the NLP Sandbox for evaluation and that are available to him/her in a safe way.

This addition slightly increase the complexity of the repo but I believe that this best practice is worth it.